### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/rspec-uuid.gemspec
+++ b/rspec-uuid.gemspec
@@ -1,16 +1,14 @@
 require_relative "lib/rspec/uuid/version"
-package = RSpec::UUID
-package_name = "rspec-uuid"
 
 Gem::Specification.new do |s|
   s.authors     = ["Daniel Pepper"]
   s.description = "RSpec UUID matcher"
   s.files       = `git ls-files * ':!:spec'`.split("\n")
-  s.homepage    = "https://github.com/dpep/#{package_name}"
+  s.homepage    = "https://github.com/dpep/rspec-uuid"
   s.license     = "MIT"
-  s.name        = package_name
-  s.summary     = package.to_s
-  s.version     = package.const_get "VERSION"
+  s.name        = "rspec-uuid"
+  s.summary     = "RSpec::UUID"
+  s.version     = RSpec::UUID::VERSION
 
   s.required_ruby_version = ">= 3.3"
 


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and only handles literal `s.name = "string"` and `s.version = SomeConst::VERSION`. The dynamic forms we had defeated that.

When dependabot can't extract the version statically it falls back to `0.0.1` and writes that into `Gemfile.lock`, which then fails CI in frozen mode (gem version mismatch). See dpep/meddleware_rb#18 for the original diagnosis.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = "rspec-uuid"
s.version = RSpec::UUID::VERSION
```


## Test plan

- [x] `Bundler.load_gemspec("rspec-uuid.gemspec")` parses statically to name=`rspec-uuid`, version=`0.6.0`
- [x] `bundle install` runs cleanly

## Pattern reference

- dpep/meddleware_rb#18 (diagnosis)
- dpep/amenable_rb#7 (template)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
