### PR TITLE
Anchor UUID regex to full string

### DIFF
--- a/lib/rspec/uuid.rb
+++ b/lib/rspec/uuid.rb
@@ -11,7 +11,7 @@ RSpec::Matchers.define :be_a_uuid do |version: nil|
     return false unless actual.is_a?(String)
 
     # https://www.uuidtools.com/what-is-uuid
-    matches = actual.match /^\h{8}-\h{4}-(\h{4})-\h{4}-\h{12}$/
+    matches = actual.match /\A\h{8}-\h{4}-(\h{4})-\h{4}-\h{12}\z/
     return false unless matches
 
     version ||= @version

--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -24,6 +24,10 @@ describe "be_a_uuid" do
     specify { expect(123).not_to be_a_uuid }
     specify { expect(nil).not_to be_a_uuid }
 
+    specify "with extra lines" do
+      expect("#{SecureRandom.uuid}\nnot-a-uuid").not_to be_a_uuid
+    end
+
     it "fails with a useful message" do
       expect {
         expect(nil).to be_a_uuid


### PR DESCRIPTION
Use `\A...\z` instead of `^...$` so a multi-line string with a valid UUID on one line plus other content no longer matches.

```ruby
# before this fix, the following incorrectly passed:
expect("992c94bd-5870-4e02-ad2d-a9435f7fffe6\nnot-a-uuid").to be_a_uuid
```

Adds a spec for the multi-line case.

🤖 vibed with Claude Code